### PR TITLE
Collection naming adjustments

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,11 +17,16 @@ _ = require('underscore');
 
 owl = require('owl-deepcopy');
 
-mongoose.mtModel = function(name, schema, collectionDelimiter) {
+var collectionDelimiter = '__';
 
-  if(!collectionDelimiter){
-      collectionDelimiter = '__';
-  }
+module.exports = function(delimiter){
+    if(delimiter){
+        collectionDelimiter = delimiter;
+    }
+};
+
+mongoose.mtModel = function(name, schema) {
+
   var extendPathWithTenantId, extendSchemaWithTenantId, modelName, multitenantSchemaPlugin, newSchema, origSchema, parts, pre, preModelName, precompile, split, tenantId, tenantModelName, uniq, _i, _len;
   precompile = [];
   extendPathWithTenantId = function(tenantId, path) {


### PR DESCRIPTION
Hopefully I'm doing this right.  I've added the logic to allow dots in the tenantId as well as a constructor that will allow optionally allow the user to set their own delimiter (but defaults to "__").  So you can do either:

`require('mongoose-multitenant');`

or

`require('mongoose-multitenant')('myDelimiterGoesHere');`
