### PR TITLE
adds support to specify the collection name manually

### DIFF
--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -80,9 +80,9 @@ mongoose.mtModel = (name, schema, collectionName) ->
 		return newSchema
 
 	multitenantSchemaPlugin = (schema, options) ->
-		schema.methods.getTenantId = ->
+		schema.statics.getTenantId = schema.methods.getTenantId = ->
 			return @schema.$tenantId
-		schema.methods.getModel = (name) ->
+		schema.statics.getModel = schema.methods.getModel = (name) ->
 			return mongoose.mtModel(@getTenantId() + '.' + name)
 		
 	# If the name has dot notation, then they want to get that model for that tenant. If it hasn't yet been

--- a/index.js
+++ b/index.js
@@ -98,10 +98,10 @@ mongoose.mtModel = function(name, schema, collectionName) {
     return newSchema;
   };
   multitenantSchemaPlugin = function(schema, options) {
-    schema.methods.getTenantId = function() {
+    schema.statics.getTenantId = schema.methods.getTenantId = function() {
       return this.schema.$tenantId;
     };
-    return schema.methods.getModel = function(name) {
+    return schema.statics.getModel = schema.methods.getModel = function(name) {
       return mongoose.mtModel(this.getTenantId() + '.' + name);
     };
   };


### PR DESCRIPTION
I needed this to map GridFS collections (e.g photos.files and photos.chunks).

``` javascript
mongoose.mtModel('Photo', schema, 'photos.files');
```
