### PR TITLE
Adding repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "grunt-contrib-coffee": "~0.8.0",
     "grunt-sed": "~0.1.1",
     "semver": "~2.2.1",
-    "should": "~2.1.1"
+    "should": "~2.1.1",
+    "mongoose": "~3.8.3"
   },
   "peerDependencies": {
     "mongoose": ">=3.x"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "mongoose": "~3.8.3",
     "mongoose-schema-extend": "~0.1.7",
     "dot-component": "~0.1.0",
     "underscore": "~1.5.2",
@@ -40,5 +39,8 @@
     "grunt-sed": "~0.1.1",
     "semver": "~2.2.1",
     "should": "~2.1.1"
+  },
+  "peerDependencies": {
+    "mongoose": ">=3.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "mongoose-multitenant",
   "version": "0.8.1",
   "description": "Wrapper for Mongoose that allows for easy horizontal multitenancy (collection prefix per tenant)",
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/jraede/mongoose-multitenant.git"
+  },
   "main": "index.js",
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
Hey, neat module. I noticed that npm didn't know what repository to link to on npmjs.com so I had to Google it. Adding the repository field should fix that the next time you do a `npm publish`.